### PR TITLE
Clarify that JupyterHub on OpenShift is a different project

### DIFF
--- a/doc/source/redhat/step-zero-openshift.rst
+++ b/doc/source/redhat/step-zero-openshift.rst
@@ -4,10 +4,10 @@ JupyterHub on OpenShift
 -----------------------
 
 [OpenShift](https://openshift.org/) from RedHat is a cluster manager based on Kubernetes.
-This guide uses [helm](https://helm.sh), which is unfortunately not well supported on OpenShift.
 
-We recommend checking out the [JupyterHub on OpenShift](https://github.com/jupyter-on-openshift/jupyterhub-quickstart)
-project instead. It provides an OpenShift template based JupyterHub installation.
+For setting up JupyterHub on OpenShift, checking out the [JupyterHub on OpenShift](https://github.com/jupyter-on-openshift/jupyterhub-quickstart)
+project. It provides an OpenShift template based JupyterHub deployment. Zero to JupyterHub uses
+[helm](https://helm.sh) which is currently not very compatible with OpenShift.
 
 Additional resources about Jupyter on OpenShift
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/redhat/step-zero-openshift.rst
+++ b/doc/source/redhat/step-zero-openshift.rst
@@ -1,33 +1,17 @@
 .. _redhat-openshift:
 
-Step Zero: Kubernetes on Red Hat OpenShift
-------------------------------------------
+JupyterHub on OpenShift
+-----------------------
 
-The easiest and recommended way to deploy JupyterHub on OpenShift
-is to follow the Red Hat instructions at the Red Hat GitHub repo
-`jupyter-on-openshift/jupyterhub-quickstart <https://github.com/jupyter-on-openshift/jupyterhub-quickstart>`_. 
-This repo's ``README`` file steps you through the process to get from OpenShift
-to a running JupyterHub cluster.
+[OpenShift](https://openshift.org/) from RedHat is a cluster manager based on Kubernetes.
+This guide uses [helm](https://helm.sh), which is unfortunately not well supported on OpenShift.
 
-From the `README <https://github.com/jupyter-on-openshift/jupyterhub-quickstart/blob/master/README.md>`_:
-
-	This repository aims to provide a much easier way of deploying JupyterHub
-	to OpenShift which makes better use of OpenShift specific features,
-	including OpenShift templates, and Source-to-Image (S2I) builders. The
-	result is a method for deploying JupyterHub to OpenShift which doesn't
-	require any special admin privileges to the underlying Kubernetes cluster,
-	or OpenShift. As long as a user has the necessary quotas for memory, CPU
-	and persistent storage, they can deploy JupyterHub themselves.
-
-
-1.  Follow the steps in the `README <https://github.com/jupyter-on-openshift/jupyterhub-quickstart/blob/master/README.md>`_.
-
-Congrats. You should now have a running JupyterHub.
+We recommend checking out the [JupyterHub on OpenShift](https://github.com/jupyter-on-openshift/jupyterhub-quickstart)
+project instead. It provides an OpenShift template based JupyterHub installation.
 
 Additional resources about Jupyter on OpenShift
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An excellent series of OpenShift blog posts on Jupyter and OpenShift
-authored by Red Hat developer, Graham Dumpleton, are 
-available on the `OpenShift blog <https://blog.openshift.com/tag/jupyter/>`_.
-The first in a series of seven posts begins `here <https://blog.openshift.com/tag/jupyter/>`_.
+- An excellent series of OpenShift blog posts on Jupyter and OpenShift
+  authored by Red Hat developer, Graham Dumpleton, are
+  available on the `OpenShift blog <https://blog.openshift.com/tag/jupyter/>`_.


### PR DESCRIPTION
On experimenting, it turns out helm on OpenShift is very poorly supported.
I don't think we can run zero to jupyterhub on OpenShift without more work
done on both the OpenShift and z2jh sides.

This commit clarifies that JupyterHub on OpenShift is a different project,
and the rest of this guide can not be used alongside it.